### PR TITLE
feature: add delay seconds config

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type Service struct {
 	RemainAfterExit bool          `mapstructure:"remain_after_exit"`
 	RestartSec      uint64        `mapstructure:"restart_sec"`
 	TimeoutStopSec  uint64        `mapstructure:"timeout_stop_sec"`
+	StartDelaySec   uint64        `mapstructure:"start_delay_sec"`
 	Env             Env           `mapstructure:"env"`
 	User            string        `mapstructure:"user"`
 }
@@ -45,6 +46,10 @@ func (c *Config) InitDefault() {
 			// default 5 seconds
 			if v.TimeoutStopSec == 0 {
 				v.TimeoutStopSec = 5
+			}
+
+			if v.StartDelaySec <= 0 {
+				v.StartDelaySec = 0
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shellphy/service/v5
+module github.com/roadrunner-server/service/v5
 
 go 1.23
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/roadrunner-server/service/v5
+module github.com/shellphy/service/v5
 
 go 1.23
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -309,6 +309,8 @@ golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=
 golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.15.0 h1:ugBLEUaxABaB5AJqW9enI0ACdci2RUd4eP51NTBvuJ8=
 golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
 golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
@@ -348,6 +350,8 @@ golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c
 golang.org/x/tools v0.23.0/go.mod h1:pnu6ufv6vQkll6szChhK3C3L/ruaIv5eBeztNG8wtsI=
 golang.org/x/tools v0.24.0 h1:J1shsA93PJUEVaUSaay7UXAyE8aimq3GW0pjlolpa24=
 golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ=
+golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
+golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/api v0.122.0 h1:zDobeejm3E7pEG1mNHvdxvjs5XJoCMzyNH+CmwL94Es=

--- a/plugin.go
+++ b/plugin.go
@@ -85,7 +85,7 @@ func (p *Plugin) Serve() chan error {
 					p.logger.Info("service will start with delay",
 						zap.String("name", key.(string)),
 						zap.String("command", cmdStr),
-						zap.Duration("delay", delayDuration))
+						zap.Uint64("delay", procs[i].service.StartDelaySec))
 
 					go func(proc *Process, name string, cmd string) {
 						time.Sleep(delayDuration)
@@ -96,7 +96,8 @@ func (p *Plugin) Serve() chan error {
 						}
 						p.logger.Info("service was started after delay",
 							zap.String("name", name),
-							zap.String("command", cmd))
+							zap.String("command", cmd),
+							zap.Uint64("delayed_seconds", proc.service.StartDelaySec))
 					}(procs[i], key.(string), cmdStr)
 				} else {
 					err := procs[i].start()

--- a/plugin.go
+++ b/plugin.go
@@ -85,7 +85,7 @@ func (p *Plugin) Serve() chan error {
 					p.logger.Info("service will start with delay",
 						zap.String("name", key.(string)),
 						zap.String("command", cmdStr),
-						zap.Uint64("delay", procs[i].service.StartDelaySec))
+						zap.Uint64("delay_seconds", procs[i].service.StartDelaySec))
 
 					go func(proc *Process, name string, cmd string) {
 						time.Sleep(delayDuration)


### PR DESCRIPTION
# Reason for This PR

Add delay start feature to service plugin. This is useful when services need to wait for other dependencies to be fully initialized (like database, cache) before starting

## Description of Changes

1. Added `start_delay_sec` field to Service struct (default: 0, immediate start)
2. Modified service plugin to support delayed starts using goroutines
3. Added relevant logging for delayed service starts

Example:
```yaml
service:
  worker:
    command: "php myscript.php"
    start_delay_sec: 5  # start after 5 seconds
    process_num: 1

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a delay mechanism for starting services, allowing for a configurable start delay.
	- Added logging to inform users when a service is starting with a delay or immediately.

- **Bug Fixes**
	- Ensured that the start delay defaults to zero if not specified, preventing potential issues with service initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->